### PR TITLE
Check if Entity is Seat & Marked Seats with NBT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
 
     <groupId>com.danichef</groupId>
     <artifactId>Rest</artifactId>
+    <packaging>jar</packaging>
     <version>1.0-SNAPSHOT</version>
 
     <repositories>
@@ -65,6 +66,7 @@
         </resources>
     </build>
 
+
     <profiles>
         <profile>
             <id>copy-jar</id>
@@ -76,7 +78,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
-                        <version>2.3.1</version>
+                        <version>2.3.2</version>
                         <configuration>
                             <outputDirectory>${server-home}/plugins</outputDirectory>
                         </configuration>

--- a/src/main/java/com/danichef/rest/Rest.java
+++ b/src/main/java/com/danichef/rest/Rest.java
@@ -11,7 +11,9 @@ import com.danichef.rest.player.corpses.PlayerCorpses;
 import com.danichef.rest.player.corpses.PlayerCorpsesImpl;
 import com.danichef.rest.player.seats.PlayerSit;
 import com.danichef.rest.player.seats.PlayerSitImpl;
+import com.danichef.rest.utils.MessagesUtil;
 import lombok.Getter;
+import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class Rest extends JavaPlugin {
@@ -25,12 +27,12 @@ public class Rest extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        playerSit = new PlayerSitImpl();
+        playerSit = new PlayerSitImpl(new NamespacedKey(this, MessagesUtil.AS_KEY));
         playerCorpses = new PlayerCorpsesImpl();
         playerManager = new PlayerManagerImpl(playerCorpses);
 
         getServer().getPluginManager().registerEvents(new PlayerQuitListener(playerCorpses), this);
-        getServer().getPluginManager().registerEvents(new PlayerDismountListener(), this);
+        getServer().getPluginManager().registerEvents(new PlayerDismountListener(playerSit), this);
 
         getCommand("sit").setExecutor(new SitCommand(playerSit, playerManager));
         getCommand("lay").setExecutor(new LayCommand(playerCorpses, playerManager));

--- a/src/main/java/com/danichef/rest/commands/AdminCommand.java
+++ b/src/main/java/com/danichef/rest/commands/AdminCommand.java
@@ -42,7 +42,7 @@ public class AdminCommand implements CommandExecutor {
 
         if ((args.length == 1) && (args[0].equalsIgnoreCase("cleanse"))) {
             player.getWorld().getEntitiesByClass(ArmorStand.class).stream()
-                    .filter(a -> a.getCustomName().equals(MessagesUtil.AS_NAME))
+                    .filter(playerSit::isSeat)
                     .forEach(Entity::remove);
 
         } else if ((args.length == 2) && (Bukkit.getPlayer(args[1]) != null)) {
@@ -62,7 +62,7 @@ public class AdminCommand implements CommandExecutor {
                 }
 
             } else if (args[0].equalsIgnoreCase("stand")) {
-                if ((target.getVehicle() != null) && (target.getVehicle().getCustomName().equals(MessagesUtil.AS_NAME))) {
+                if ((target.getVehicle() != null) && (playerSit.isSeat(target.getVehicle()))) {
                     target.getVehicle().remove();
                 }
 

--- a/src/main/java/com/danichef/rest/listeners/PlayerDismountListener.java
+++ b/src/main/java/com/danichef/rest/listeners/PlayerDismountListener.java
@@ -1,6 +1,6 @@
 package com.danichef.rest.listeners;
 
-import com.danichef.rest.utils.MessagesUtil;
+import com.danichef.rest.player.seats.PlayerSit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -8,11 +8,16 @@ import org.spigotmc.event.entity.EntityDismountEvent;
 
 public class PlayerDismountListener implements Listener {
 
+    private final PlayerSit playerSit;
+
+    public PlayerDismountListener (final PlayerSit playerSit) {
+        this.playerSit = playerSit;
+    }
+
     @EventHandler
     public void onPlayerDismount(EntityDismountEvent event) {
         if(!(event.getEntity() instanceof Player)) return;
-        if ((event.getDismounted().getCustomName() == null)
-                || (!event.getDismounted().getCustomName().equals(MessagesUtil.AS_NAME))) return;
+        if (!playerSit.isSeat(event.getDismounted())) return;
 
         event.getDismounted().remove();
     }

--- a/src/main/java/com/danichef/rest/player/PlayerManager.java
+++ b/src/main/java/com/danichef/rest/player/PlayerManager.java
@@ -1,6 +1,7 @@
 package com.danichef.rest.player;
 
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 public interface PlayerManager {
 
@@ -10,5 +11,5 @@ public interface PlayerManager {
      * @param player
      * @return if player can player rest
      */
-    boolean canRest(Player player);
+    boolean canRest(@NotNull Player player);
 }

--- a/src/main/java/com/danichef/rest/player/PlayerManagerImpl.java
+++ b/src/main/java/com/danichef/rest/player/PlayerManagerImpl.java
@@ -3,6 +3,7 @@ package com.danichef.rest.player;
 import com.danichef.rest.player.corpses.PlayerCorpses;
 import com.danichef.rest.player.seats.PlayerSit;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerManagerImpl implements PlayerManager {
 
@@ -19,7 +20,7 @@ public class PlayerManagerImpl implements PlayerManager {
      * @return if player can player rest
      */
     @Override
-    public boolean canRest(Player player) {
+    public boolean canRest(@NotNull Player player) {
         if (player.isOnGround() && !player.isSleeping() && !playerCorpses.isLying(player) && player.getVehicle() == null) return true;
         return false;
     }

--- a/src/main/java/com/danichef/rest/player/corpses/PlayerCorpses.java
+++ b/src/main/java/com/danichef/rest/player/corpses/PlayerCorpses.java
@@ -1,30 +1,31 @@
 package com.danichef.rest.player.corpses;
 
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 public interface PlayerCorpses {
 
     /**
      * @param player to put to sleep
      */
-    void putToSleep(Player player);
+    void putToSleep(@NotNull Player player);
 
     /**
      * @param player to put to sleep
      * @param sendTo the players that will recieve the sleep packets
      */
-    void putToSleep(Player player, Player... sendTo);
+    void putToSleep(@NotNull Player player, @NotNull Player... sendTo);
 
     /**
      * @param player to wake up
      */
-    void wakeUp(Player player);
+    void wakeUp(@NotNull Player player);
 
     /**
      * @param player to put to sleep
      * @param sendTo the players that will recieve the wake-up packets
      */
-    void wakeUp(Player player, Player... sendTo);
+    void wakeUp(@NotNull Player player, @NotNull Player... sendTo);
 
     /**
      * Check if player is lying
@@ -32,5 +33,5 @@ public interface PlayerCorpses {
      * @param player
      * @return if player is lying
      */
-    boolean isLying(Player player);
+    boolean isLying(@NotNull Player player);
 }

--- a/src/main/java/com/danichef/rest/player/corpses/PlayerCorpsesImpl.java
+++ b/src/main/java/com/danichef/rest/player/corpses/PlayerCorpsesImpl.java
@@ -9,6 +9,7 @@ import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +39,7 @@ public class PlayerCorpsesImpl implements PlayerCorpses {
      * @param player to put to sleep
      */
     @Override
-    public void putToSleep(Player player) {
+    public void putToSleep(@NotNull Player player) {
         putToSleep(player, player.getWorld().getPlayers().toArray(new Player[0]));
     }
 
@@ -47,7 +48,7 @@ public class PlayerCorpsesImpl implements PlayerCorpses {
      * @param sendTo the players that will recieve the sleep packets
      */
     @Override
-    public void putToSleep(Player player, Player... sendTo) {
+    public void putToSleep(@NotNull Player player, @NotNull Player... sendTo) {
         try {
             List<Player> send = Arrays.asList(sendTo);
             Location playerLocation = player.getLocation().clone();
@@ -82,7 +83,7 @@ public class PlayerCorpsesImpl implements PlayerCorpses {
      * @param player to wake up
      */
     @Override
-    public void wakeUp(Player player) {
+    public void wakeUp(@NotNull Player player) {
         wakeUp(player, player.getWorld().getPlayers().toArray(new Player[0]));
     }
 
@@ -91,7 +92,7 @@ public class PlayerCorpsesImpl implements PlayerCorpses {
      * @param sendTo the players that will recieve the wake-up packets
      */
     @Override
-    public void wakeUp(Player player, Player... sendTo) {
+    public void wakeUp(@NotNull Player player, @NotNull Player... sendTo) {
         try {
             List<Player> send = Arrays.asList(sendTo);
             Location playerLocation = player.getLocation().clone();
@@ -124,7 +125,7 @@ public class PlayerCorpsesImpl implements PlayerCorpses {
      * @return if player is lying
      */
     @Override
-    public boolean isLying(Player player) {
+    public boolean isLying(@NotNull Player player) {
         return getSleepingPlayers().contains(player);
     }
 

--- a/src/main/java/com/danichef/rest/player/seats/PlayerSit.java
+++ b/src/main/java/com/danichef/rest/player/seats/PlayerSit.java
@@ -1,9 +1,27 @@
 package com.danichef.rest.player.seats;
 
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 public interface PlayerSit {
-    void sit(Player player);
 
-    void standUp(Player player);
+    /**
+     * Makes player sit
+     * @param player to sit
+     */
+    void sit(@NotNull Player player);
+
+    /**
+     * Makes player stand up
+     * @param player to stand up
+     */
+    void standUp(@NotNull Player player);
+
+    /**
+     * Returns whether the given entity is a seat or not
+     * @param entity to check
+     * @return whether the given entity is a seat or not
+     */
+    boolean isSeat(@NotNull Entity entity);
 }

--- a/src/main/java/com/danichef/rest/player/seats/PlayerSitImpl.java
+++ b/src/main/java/com/danichef/rest/player/seats/PlayerSitImpl.java
@@ -1,39 +1,57 @@
 package com.danichef.rest.player.seats;
 
+import com.danichef.rest.Rest;
 import com.danichef.rest.utils.MessagesUtil;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
 
 public class PlayerSitImpl implements PlayerSit {
 
+    private final NamespacedKey key;
+
+    public PlayerSitImpl(final NamespacedKey key) { this.key = key; }
+
     /**
      * Makes player sit
-     * @param player
+     * @param player to sit
      */
     @Override
-    public void sit(Player player) {
+    public void sit(@NotNull Player player) {
         Location location = player.getLocation();
 
         ArmorStand seat = location.getWorld().spawn(location.clone().subtract(0.0D, 1.7D, 0.0D), ArmorStand.class);
         seat.setGravity(false);
         seat.setVisible(false);
-        seat.setCustomNameVisible(false);
-        seat.setCustomName(MessagesUtil.AS_NAME);
+        seat.getPersistentDataContainer().set(key, PersistentDataType.STRING, "");
         seat.addPassenger(player);
     }
 
     /**
      * Makes player stand up
-     * @param player
+     * @param player to stand up
      */
     @Override
-    public void standUp(Player player)  {
+    public void standUp(@NotNull Player player)  {
         if (player.getVehicle() == null) return;
-        if (!player.getVehicle().getCustomName().equals(MessagesUtil.AS_NAME)) return;
+        if (!isSeat(player.getVehicle())) return;
 
         Location location = player.getLocation().clone().add(0, 1, 0);
         player.getVehicle().remove();
         player.teleport(location);
+    }
+
+    /**
+     * Returns whether the given entity is a seat or not
+     * @param entity to check
+     * @return whether the given entity is a seat or not
+     */
+    @Override
+    public boolean isSeat(@NotNull Entity entity) {
+        return (entity.getPersistentDataContainer().has(key, PersistentDataType.STRING));
     }
 }

--- a/src/main/java/com/danichef/rest/utils/MessagesUtil.java
+++ b/src/main/java/com/danichef/rest/utils/MessagesUtil.java
@@ -6,7 +6,7 @@ public class MessagesUtil {
 
     public static final String PREFIX = ChatColor.DARK_GRAY + "[" + ChatColor.DARK_AQUA + "SimpleRest" + ChatColor.DARK_GRAY + "] ";
 
-    public static final String AS_NAME = "Seat";
+    public static final String AS_KEY = "seat";
 
     public static final String NO_GROUND = ChatColor.AQUA + "Must be on the floor to rest!";
     public static final String SITTING = ChatColor.AQUA + "You are now sitting";


### PR DESCRIPTION
Before this commit there would nto be a method to check if a seat was a seat nor were seats marked in the cleanest of ways. This prevented plugins in KTN such as "Hospital" to check if the entities were seats or not.

As of this commit, PlayerSit interface contains a method to check if an entity is a seat as well as seats being marked with NBT tags instead of with a custom name. This will allow seats to be detectable by other plugins as well as the seats being tracked in a neat way.

Resolves: #3 [[link]](https://github.com/KnockturnMC/Rest/issues/3)